### PR TITLE
@W-22855769 [fix] stabilize build by bumping MUnit pom versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
         <jacoco.version>0.8.13</jacoco.version>
         <tika.version>2.9.4</tika.version>
         <mockito.version>4.11.0</mockito.version>
-        <munit.extensions.maven.plugin.version>1.6.0</munit.extensions.maven.plugin.version>
-        <munit.version>3.6.1</munit.version>
+        <munit.extensions.maven.plugin.version>1.7.0</munit.extensions.maven.plugin.version>
+        <munit.version>3.7.0</munit.version>
         <maven.surefire.version>3.5.3</maven.surefire.version>
         <runtimeProduct>MULE_EE</runtimeProduct>
     </properties>


### PR DESCRIPTION
Bumps munit-extensions-maven-plugin 1.6.0 -> 1.7.0 and MUnit 3.6.1 -> 3.7.0 to resolve JDK 17 / Mule 4.6.31 embedded-container startup failures (IllegalCallerException: javax.naming is not open). 
Co-Authored-By:
Claude Opus 4.7 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)